### PR TITLE
adding options to select an ipaddress during setup

### DIFF
--- a/factioncli/processing/setup/networking.py
+++ b/factioncli/processing/setup/networking.py
@@ -1,0 +1,20 @@
+import socket, struct, fcntl  # fcntl is unix only
+
+def get_nics():
+    return socket.if_nameindex()
+
+def get_hw_addr(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(fcntl.ioctl(
+        s.fileno(),
+        0x8915,  # SIOCGIFADDR
+        struct.pack('256s', bytes(ifname[:15],'utf-8'))
+    )[20:24])
+
+def get_ip_addresses():
+    ip_addresses = {}
+    res = get_nics()
+    for r in res:
+        ip_addresses[r[1]] = get_hw_addr(r[1])
+    return ip_addresses
+


### PR DESCRIPTION
a few changes, feel  free to critique, reject or ignore

1) added in functionality to provide user with a list of nics and associated ip addresses during setup should they want to select one.
2) fixed a bug -> the previous logic of if not or not would fail, whereas if not (option a or option b) works.
3) abstracted out networking logic to a new file called networking.py in the setup folder (guess as to where it belongs)