### PR TITLE
faction setup --build fixed

### DIFF
--- a/factioncli/commands/setup.py
+++ b/factioncli/commands/setup.py
@@ -117,7 +117,7 @@ class Setup(Command):
 
         if parsed_args.build:
             for component in parsed_args.components:
-                download_github_repo("FactionC2/{0}".format(component), "{0}/source/{1}".format(parsed_args.faction_path, component), parsed_args.github_pat)
+                download_github_repo("FactionC2/{0}".format(component), "{0}/source/{1}".format(parsed_args.faction_path, component), component, parsed_args.github_pat)
             write_build_compose_file()
         elif parsed_args.dev:
             write_dev_compose_file()

--- a/factioncli/main.py
+++ b/factioncli/main.py
@@ -9,7 +9,7 @@ class FactionCli(App):
     def __init__(self):
         super(FactionCli, self).__init__(
             description='Faction CLI',
-            version='2019.4.21',
+            version='2019.6.07',
             command_manager=CommandManager('faction.cli'),
             deferred_help=True,
             )

--- a/factioncli/processing/docker/compose.py
+++ b/factioncli/processing/docker/compose.py
@@ -29,7 +29,7 @@ services:
       - RABBITMQ_DEFAULT_USER={3}
       - RABBITMQ_DEFAULT_PASS={4}
   console:
-    build: ../services/console
+    build: ../source/Console
     ports:
       - "{8}:443"
     depends_on:
@@ -37,7 +37,7 @@ services:
     volumes:
       - {0}/certs:/opt/faction/certs
   api:
-    build: ../source/api
+    build: ../source/API
     depends_on:
       - mq
       - db
@@ -56,7 +56,7 @@ services:
       - RABBIT_USERNAME={3}
       - RABBIT_PASSWORD={4}
   core:
-    build: ../source/core
+    build: ../source/Core
     depends_on:
       - mq
       - db
@@ -72,7 +72,7 @@ services:
       - SYSTEM_USERNAME={11}
       - SYSTEM_PASSWORD={12}
   build-server-dotnet:
-    build: ../source/build-server-dotnet
+    build: ../source/Build-Service-Dotnet
     depends_on:
       - core
       - api

--- a/factioncli/processing/faction/repo.py
+++ b/factioncli/processing/faction/repo.py
@@ -14,7 +14,7 @@ def clone_github_repo(repo_name, output_dir):
     command = "git clone https://github.com/{0} {1}".format(repo_name, output_dir)
     subprocess.call(command, shell=True)
 
-def download_github_repo(repo_name, output_dir, access_token=None):
+def download_github_repo(repo_name, output_dir, alone_dir, access_token=None):
     print_output("Downloading module: {0}".format(repo_name))
     log.debug("Access Token: {0}".format(access_token))
     url = "https://api.github.com/repos/{0}/zipball".format(repo_name)
@@ -37,12 +37,12 @@ def download_github_repo(repo_name, output_dir, access_token=None):
     print_output("Opening Zip File {0}".format(temporary_zip.name))
     zip_ref = zipfile.ZipFile(temporary_zip.name, 'r')
 
-    log.debug("Extracting Zip")
-    print_output("Extracting Zip File {0}".format(temporary_zip.name))
-
     temporary_dir = tempfile.mkdtemp()
     log.debug("Creating Temporary Dir: {0}".format(temporary_dir))
     print_output("Creating Temporary Dir: {0}".format(temporary_dir))
+
+    log.debug("Extracting Zip")
+    print_output("Extracting Zip File {0}".format(temporary_zip.name))
     zip_ref.extractall(temporary_dir)
 
     log.debug("Buildling source folder")
@@ -67,7 +67,7 @@ def download_github_repo(repo_name, output_dir, access_token=None):
         print_output("Cleaning out {0}".format(output_dir))
         shutil.rmtree(output_dir, ignore_errors=True)
 
-    path.mkdir(parents=True, exist_ok=True)
+    # path.mkdir(parents=True, exist_ok=True)
 
     module_files = os.listdir(source_path)
     print_output("Moving files to {0}".format(output_dir))

--- a/factioncli/processing/faction/repo.py
+++ b/factioncli/processing/faction/repo.py
@@ -30,31 +30,41 @@ def download_github_repo(repo_name, output_dir, access_token=None):
         r = requests.get(url, allow_redirects=True)
 
     log.debug("Writing Zip")
+    print_output("Writing Zip File {0}".format(temporary_zip.name))
     temporary_zip.write(r.content)
 
     log.debug("Opening Zip")
+    print_output("Opening Zip File {0}".format(temporary_zip.name))
     zip_ref = zipfile.ZipFile(temporary_zip.name, 'r')
 
     log.debug("Extracting Zip")
-
+    print_output("Extracting Zip File {0}".format(temporary_zip.name))
 
     temporary_dir = tempfile.mkdtemp()
     log.debug("Creating Temporary Dir: {0}".format(temporary_dir))
+    print_output("Creating Temporary Dir: {0}".format(temporary_dir))
     zip_ref.extractall(temporary_dir)
+
     log.debug("Buildling source folder")
 
     repo_path = repo_name.replace('/', '-')
     source_path = os.path.join(temporary_dir, "{0}-{1}".format(repo_path, zip_ref.comment.decode()))
 
     log.debug("Checking for source path: {0}".format(source_path))
+    print_output("Checking for source path: {0}".format(source_path))
     if not os.path.exists(source_path):
         source_path = temporary_dir
 
     log.debug("Source Path: {0}".format(source_path))
     log.debug("Creating output directory: {0}".format(output_dir))
+
+    print_output("Source Path: {0}".format(source_path))
+    print_output("Creating output directory: {0}".format(output_dir))
+
     path = Path(output_dir)
     if path.exists():
         log.debug("Cleaning out {0}".format(output_dir))
+        print_output("Cleaning out {0}".format(output_dir))
         shutil.rmtree(output_dir, ignore_errors=True)
 
     path.mkdir(parents=True, exist_ok=True)
@@ -64,6 +74,7 @@ def download_github_repo(repo_name, output_dir, access_token=None):
     for module_file in module_files:
         module_file_path = os.path.join(source_path, module_file)
         log.debug("Moving {0}".format(module_file_path))
+        print_output("Moving {0}".format(module_file_path))
         shutil.move(module_file_path, output_dir)
 
     zip_ref.close()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 PROJECT = 'Faction CLI'
 
 # Change docs/sphinx/conf.py too!
-VERSION = '2019.04.21'
+VERSION = '2019.06.07'
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
On Ubuntu 19.04, using --build option on faction setup doesn't work!

This patch contains
- write_build_compose_file function in [compose.py](https://github.com/FactionC2/CLI/blob/master/factioncli/processing/docker/compose.py): fixed paths for source code for build, now folder name is equal to repo name
- path creation in [repo.py](https://github.com/FactionC2/CLI/blob/master/factioncli/processing/faction/repo.py) removed because when I move the temporary directory, python nests it into the correct one
- setup --build output a little bit verbose :)

For reproduce the build procedure before merge:
```
curl https://raw.githubusercontent.com/s3b4stian/Faction/master/install.sh | sudo bash
faction setup --build
```
