### PR TITLE
build server container name updated/fixed

### DIFF
--- a/factioncli/processing/docker/compose.py
+++ b/factioncli/processing/docker/compose.py
@@ -71,7 +71,7 @@ services:
       - RABBIT_PASSWORD={4}
       - SYSTEM_USERNAME={11}
       - SYSTEM_PASSWORD={12}
-  build-server-dotnet:
+  build-dotnet:
     build: ../source/Build-Service-Dotnet
     depends_on:
       - core


### PR DESCRIPTION
Container name updated/fixed for build-service-dotnet when created with [write_build_compose_file](https://github.com/FactionC2/CLI/blob/development/factioncli/processing/docker/compose.py). 

Now is equal to counterpart in write_hub_compose_file.
 
This fix prevent command "faction status" to fail due to container wrong name.