### PR TITLE
Docker logging fix

### DIFF
--- a/factioncli/commands/setup.py
+++ b/factioncli/commands/setup.py
@@ -88,6 +88,12 @@ class Setup(Command):
         parser.add_argument('--postgres-password',
                             help="Password for Postgres. If not specified, a random password will be generated",
                             default=None)
+        parser.add_argument('--log-file-size',
+                            help="Size to make log files before being archived.",
+                            default="250m")
+        parser.add_argument('--log-file-number',
+                            help="Number of log files to archive before rolling over.",
+                            default="5")
         return parser
 
     def take_action(self, parsed_args):
@@ -125,7 +131,9 @@ class Setup(Command):
                              rabbit_username=parsed_args.rabbit_username,
                              rabbit_password=parsed_args.rabbit_password,
                              system_username=parsed_args.system_username,
-                             system_password=parsed_args.system_password)
+                             system_password=parsed_args.system_password,
+                             log_file_size=parsed_args.log_file_size,
+                             log_file_number=parsed_args.log_file_number)
 
         if parsed_args.build:
             for component in parsed_args.components:

--- a/factioncli/processing/config/__init__.py
+++ b/factioncli/processing/config/__init__.py
@@ -75,6 +75,8 @@ def generate_config_file(admin_username,
                          rabbit_password,
                          system_username,
                          system_password,
+                         log_file_size,
+                         log_file_number
                          ):
 
     if not flask_secret:
@@ -118,7 +120,9 @@ def generate_config_file(admin_username,
         "POSTGRES_HOST": postgres_host,
         "POSTGRES_DATABASE": postgres_database,
         "POSTGRES_USERNAME": postgres_username,
-        "POSTGRES_PASSWORD": postgres_password
+        "POSTGRES_PASSWORD": postgres_password,
+        "LOG_FILE_SIZE": log_file_size,
+        "LOG_FILE_NUMBER": log_file_number
     })
 
     write_config(config)

--- a/factioncli/processing/docker/compose.py
+++ b/factioncli/processing/docker/compose.py
@@ -8,7 +8,15 @@ def write_build_compose_file():
     docker_compose_file_path = os.path.join(config["FACTION_PATH"], "install/docker-compose.yml")
 
     docker_compose_file_contents = """
-version: "3"
+version: "3.4"
+
+x-logging: 
+      &default-logging
+      driver: local
+      options:
+        max-size: "{13}"
+        max-file: "{14}"
+
 services:
   db:
     image: postgres:latest
@@ -20,6 +28,7 @@ services:
       - POSTGRES_DB={6}
       - POSTGRES_USERNAME={1}
       - POSTGRES_PASSWORD={2}
+    logging: *default-logging
   mq:
     image: rabbitmq:3-management
     ports:
@@ -28,6 +37,7 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER={3}
       - RABBITMQ_DEFAULT_PASS={4}
+    logging: *default-logging
   console:
     build: ../source/Console
     ports:
@@ -36,6 +46,7 @@ services:
       - api
     volumes:
       - {0}/certs:/opt/faction/certs
+    logging: *default-logging
   api:
     build: ../source/API
     depends_on:
@@ -55,6 +66,7 @@ services:
       - RABBIT_HOST={7}
       - RABBIT_USERNAME={3}
       - RABBIT_PASSWORD={4}
+    logging: *default-logging
   core:
     build: ../source/Core
     depends_on:
@@ -71,6 +83,7 @@ services:
       - RABBIT_PASSWORD={4}
       - SYSTEM_USERNAME={11}
       - SYSTEM_PASSWORD={12}
+    logging: *default-logging
   build-dotnet:
     build: ../source/Build-Service-Dotnet
     depends_on:
@@ -86,11 +99,12 @@ services:
       - RABBIT_HOST={7}
       - RABBIT_USERNAME={3}
       - RABBIT_PASSWORD={4}
+    logging: *default-logging
 """.format(config["FACTION_PATH"], config["POSTGRES_USERNAME"], config["POSTGRES_PASSWORD"],
            config["RABBIT_USERNAME"], config["RABBIT_PASSWORD"], config["POSTGRES_HOST"],
            config["POSTGRES_DATABASE"], config["RABBIT_HOST"], config["CONSOLE_PORT"],
            config["FLASK_SECRET"], config["API_UPLOAD_DIR"], config["SYSTEM_USERNAME"],
-           config["SYSTEM_PASSWORD"])
+           config["SYSTEM_PASSWORD"], config["LOG_FILE_SIZE"], config["LOG_FILE_NUMBER"])
 
     with open(docker_compose_file_path, "w+") as compose_file:
         compose_file.write(docker_compose_file_contents)
@@ -102,7 +116,15 @@ def write_hub_compose_file():
     docker_compose_file_path = os.path.join(config["FACTION_PATH"], "install/docker-compose.yml")
 
     docker_compose_file_contents = """
-version: "3"
+version: "3.4"
+
+x-logging: 
+      &default-logging
+      driver: local
+      options:
+        max-size: "{13}"
+        max-file: "{14}"
+
 services:
   db:
     image: postgres:latest
@@ -114,6 +136,7 @@ services:
       - POSTGRES_DB={6}
       - POSTGRES_USERNAME={1}
       - POSTGRES_PASSWORD={2}
+    logging: *default-logging
   mq:
     image: rabbitmq:3-management
     ports:
@@ -122,6 +145,7 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER={3}
       - RABBITMQ_DEFAULT_PASS={4}
+    logging: *default-logging
   console:
     image: faction/console:latest
     ports:
@@ -130,6 +154,7 @@ services:
       - api
     volumes:
       - {0}/certs:/opt/faction/certs
+    logging: *default-logging
   api:
     image: faction/api:latest
     depends_on:
@@ -149,6 +174,7 @@ services:
       - RABBIT_HOST={7}
       - RABBIT_USERNAME={3}
       - RABBIT_PASSWORD={4}
+    logging: *default-logging
   core:
     image: faction/core:latest
     depends_on:
@@ -165,6 +191,7 @@ services:
       - RABBIT_PASSWORD={4}
       - SYSTEM_USERNAME={11}
       - SYSTEM_PASSWORD={12}
+    logging: *default-logging
   build-dotnet:
     image: faction/build-dotnet:latest
     depends_on:
@@ -180,11 +207,12 @@ services:
       - RABBIT_HOST={7}
       - RABBIT_USERNAME={3}
       - RABBIT_PASSWORD={4}
+    logging: *default-logging
 """.format(config["FACTION_PATH"], config["POSTGRES_USERNAME"], config["POSTGRES_PASSWORD"],
            config["RABBIT_USERNAME"], config["RABBIT_PASSWORD"], config["POSTGRES_HOST"],
            config["POSTGRES_DATABASE"], config["RABBIT_HOST"], config["CONSOLE_PORT"],
            config["FLASK_SECRET"], config["API_UPLOAD_DIR"], config["SYSTEM_USERNAME"],
-           config["SYSTEM_PASSWORD"])
+           config["SYSTEM_PASSWORD"], config["LOG_FILE_SIZE"], config["LOG_FILE_NUMBER"])
 
     with open(docker_compose_file_path, "w+") as compose_file:
         compose_file.write(docker_compose_file_contents)
@@ -195,7 +223,13 @@ def write_dev_compose_file():
     docker_compose_file_path = os.path.join(config["FACTION_PATH"], "install/docker-compose.yml")
 
     docker_compose_file_contents = """
-version: "3"
+version: "3.4"
+x-logging: 
+      &default-logging
+      driver: local
+      options:
+        max-size: "{7}"
+        max-file: "{8}"
 services:
   db:
     image: postgres:latest
@@ -207,6 +241,7 @@ services:
       - POSTGRES_DB={6}
       - POSTGRES_USERNAME={1}
       - POSTGRES_PASSWORD={2}
+    logging: *default-logging
   mq:
     image: rabbitmq:3-management
     ports:
@@ -215,9 +250,10 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER={3}
       - RABBITMQ_DEFAULT_PASS={4}
+    logging: *default-logging
 """.format(config["FACTION_PATH"], config["POSTGRES_USERNAME"], config["POSTGRES_PASSWORD"],
            config["RABBIT_USERNAME"], config["RABBIT_PASSWORD"], config["POSTGRES_HOST"],
-           config["POSTGRES_DATABASE"])
+           config["POSTGRES_DATABASE"], config["LOG_FILE_SIZE"], config["LOG_FILE_NUMBER"])
 
     with open(docker_compose_file_path, "w+") as compose_file:
         compose_file.write(docker_compose_file_contents)


### PR DESCRIPTION
1. Added parameters to set for log size and number of logs before rollover. Defaults to GZ compression.
- log_file_size (defaults to 250mb) - Had it at 500mb but I believe that's a lot even for the console or build-dotnet services. Can always change later or now, your call.
- log_file_number (defaults to 5)

2. Moved the Docker Compose file version to 3.4 to support x-logging extension

3. Created a logging extension YAML anchor (&default-logging) for the "local" (stdout) logging driver and assigned it to all services. The reason for this is for future possibilities of automatic import to red team SIEM solution or other remote/alternative logging. Can set another YAML anchor for remote, ask for info during setup and automatically import to the docker compose file.

![image](https://user-images.githubusercontent.com/18420902/64994445-e5e18680-d895-11e9-8a48-ff4592325adf.png)

****Tested on a fresh install of Ubuntu 18.04 and worked as intended* (tested with 10kb file size to  confirm size/rollover). faction clean --all && faction setup afterwards worked as intended as well.**

**Also tested on current install. faction clean --all && faction setup.**

Disregard the other comments if you can see them. I derped.